### PR TITLE
chore: Upgrade pulumi to latest bugfix

### DIFF
--- a/Dockertempl.pulumi
+++ b/Dockertempl.pulumi
@@ -1,4 +1,4 @@
-RUN VERSION=v2.15.5 && \
+RUN VERSION=v2.15.6 && \
     export NVM_DIR="/usr/local/nvm" && \
     . "$NVM_DIR/nvm.sh" && \
     nvm use stable && \


### PR DESCRIPTION
The release notes state an important fix:
Fix a bug in the Go SDK that could result in dropped resource dependencies.
