### PR TITLE
fix(image-cleanage): keep images tagged with latest labels

### DIFF
--- a/clean-public-repo.js
+++ b/clean-public-repo.js
@@ -9,7 +9,7 @@ async function allImages(client, allList, nextToken) {
 	if (response.nextToken) {
 		return await allImages(client, allList, response.nextToken);
 	}
-	return allList	
+	return allList
 }
 
 async function deleteImages(client, older) {
@@ -19,8 +19,8 @@ async function deleteImages(client, older) {
 	const chunk = older.splice(0, 80);
 	console.log(`deleteImages: ${chunk.length} from ${older.length}`, chunk.map(i => i.imageDigest));
 	const command = new ecrpub.BatchDeleteImageCommand({
-		repositoryName: 'developers-paradise', 
-		imageIds: chunk.map(i => ({imageDigest: i.imageDigest}))  
+		repositoryName: 'developers-paradise',
+		imageIds: chunk.map(i => ({imageDigest: i.imageDigest}))
 	});
         const response = await client.send(command);
 	console.log(JSON.stringify(response, null, 2));
@@ -28,7 +28,7 @@ async function deleteImages(client, older) {
 }
 
 const CLEAN_OLDER_DAYS = 14;
-//const AT_LEAST_VERSION = 40; 
+//const AT_LEAST_VERSION = 40;
 (async function() {
 	const client = new ecrpub.ECRPUBLICClient({ region: "us-east-1" });
 
@@ -36,8 +36,10 @@ const CLEAN_OLDER_DAYS = 14;
 
 	// console.log(all.length);
 	const start = (new Date()).getTime() - (CLEAN_OLDER_DAYS * 24 * 60 * 60 * 1000);
-	const older = all.filter(i => {
-		return (new Date(i.imagePushedAt)).getTime() < start;
+	let older = all.filter(i => {
+		// keep latest
+		const keep = imageTags.some(tag => tag.includes("latest"));
+		return (new Date(i.imagePushedAt)).getTime() < start && !keep;
 	});
 	// console.log(older.length, older.map(i => i.imageDigest));
 	await deleteImages(client, older);


### PR DESCRIPTION
@mabels could not verify if it works yet.

Documentation https://docs.aws.amazon.com/AmazonECRPublic/latest/APIReference/API_DescribeImages.html
suggests you can read image tags directly from the response of the image describe command to keep images tagged with latest labels